### PR TITLE
Default to using a relative path for root

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The following settings are optional:
  - `"autoloadFilesBehavior": "scan"|"exec"` - whether autoload `files` from vendor should be `scan`ned for definitions, or `exec`uted by `vendor/hh_autoload.php` - `scan` is the default, and generally favorable, but `exec` is needed if you have dependencies that need code to be executed on startup. `scan` is sufficient if your dependencies just use `files` because they need to define things that aren't classes, which is usually the case.
  - `"parser": "ext-factparse"|"definition-finder"` - how to parse files. FactParse is an HHVM extension in 3.18 and above, while DefinitionFinder is a library supporting older versions of HHVM.
  - `"devRoot": [ "path/", ...]` - additional roots to only include in dev mode, not when installed as a dependency.
+ - `"relativeAutoloadRoot": false` - do not use a path relative to `__DIR__` for autoloading. Instead, use the path to the folder containing `hh_autoload.json` when building the autoload map.
 
 How It Works
 ============

--- a/bin/hh-autoload
+++ b/bin/hh-autoload
@@ -91,6 +91,7 @@ final class GenerateScript {
     (new Writer())
       ->setBuilder($importer)
       ->setRoot(getcwd())
+      ->setRelativeAutoloadRoot($importer->getConfig()['relativeAutoloadRoot'])
       ->writeToFile($file);
     print($file."\n");
   }

--- a/src/ComposerPlugin.php
+++ b/src/ComposerPlugin.php
@@ -62,6 +62,7 @@ final class ComposerPlugin
     (new Writer())
       ->setBuilder($importer)
       ->setRoot($this->root)
+      ->setRelativeAutoloadRoot($importer->getConfig()['relativeAutoloadRoot'])
       ->writeToFile($this->vendor.'/hh_autoload.php');
   }
 

--- a/src/ConfigurationLoader.php
+++ b/src/ConfigurationLoader.php
@@ -22,6 +22,7 @@ abstract final class ConfigurationLoader {
     'roots' => array<string>,
     'devRoots' => ?array<string>,
     'autoloadFilesBehavior' => ?AutoloadFilesBehavior,
+    'relativeAutoloadRoot' => ?bool,
     'includeVendor' => ?bool,
     'extraFiles' => ?array<string>,
     'parser' => ?Parser,
@@ -69,6 +70,7 @@ abstract final class ConfigurationLoader {
       ),
       'autoloadFilesBehavior' => $config['autoloadFilesBehavior']
         ?? AutoloadFilesBehavior::FIND_DEFINITIONS,
+      'relativeAutoloadRoot' => $config['relativeAutoloadRoot'] ?? true,
       'includeVendor' => $config['includeVendor'] ?? true,
       'extraFiles' => self::maybeArrayToImmVector(
         $config['extraFiles'] ?? null,

--- a/src/Writer.php
+++ b/src/Writer.php
@@ -15,6 +15,7 @@ final class Writer {
   private ?ImmVector<string> $files;
   private ?AutoloadMap $map;
   private ?string $root;
+  private bool $relativeAutoloadRoot = true;
 
   public function setFiles(ImmVector<string> $files): this {
     $this->files = $files;
@@ -34,6 +35,11 @@ final class Writer {
 
   public function setRoot(string $root): this {
     $this->root = realpath($root);
+    return $this;
+  }
+
+  public function setRelativeAutoloadRoot(bool $relativeAutoloadRoot): this {
+    $this->relativeAutoloadRoot = $relativeAutoloadRoot;
     return $this;
   }
 
@@ -68,7 +74,11 @@ final class Writer {
       Shapes::toArray($map),
     );
     $map = var_export($map, true);
-    $root = var_export($this->root.'/', true);
+    if ($this->relativeAutoloadRoot) {
+      $root = '__DIR__.\'/../\'';
+    } else {
+      $root = var_export($this->root.'/', true);
+    }
     $code = <<<EOF
 <?hh
 
@@ -82,7 +92,7 @@ EOF;
       $destination_file,
       $code,
     );
-      
+
     return $this;
   }
 

--- a/src/builders/RootImporter.php
+++ b/src/builders/RootImporter.php
@@ -13,14 +13,15 @@ namespace Facebook\AutoloadMap;
 
 final class RootImporter implements Builder {
   private Vector<Builder> $builders = Vector { };
+  private HHImporter $hh_importer;
 
   public function __construct(
     string $root,
     IncludedRoots $included = IncludedRoots::PROD_ONLY,
   ) {
-    $hh_importer = new HHImporter($root, $included);
-    $this->builders[] = $hh_importer;
-    $config = $hh_importer->getConfig();
+    $this->hh_importer = new HHImporter($root, $included);
+    $this->builders[] = $this->hh_importer;
+    $config = $this->hh_importer->getConfig();
 
     if (!$config['includeVendor']) {
       return;
@@ -54,5 +55,9 @@ final class RootImporter implements Builder {
       $files->addAll($builder->getFiles());
     }
     return $files->toImmVector();
+  }
+
+  public function getConfig(): Config {
+    return $this->hh_importer->getConfig();
   }
 }

--- a/tests/ConfigurationLoaderTest.php
+++ b/tests/ConfigurationLoaderTest.php
@@ -17,6 +17,7 @@ final class ConfigurationLoaderTest extends \PHPUnit_Framework_TestCase {
     return [
       'fully specified' => [[
         'autoloadFilesBehavior' => AutoloadFilesBehavior::EXEC_FILES,
+        'relativeAutoloadRoot' => false,
         'includeVendor' => false,
         'extraFiles' => [],
         'roots' => ['foo/', 'bar/'],
@@ -77,7 +78,7 @@ final class ConfigurationLoaderTest extends \PHPUnit_Framework_TestCase {
       AutoloadFilesBehavior::coerce($config['autoloadFilesBehavior'])
     );
 
-    $config = Shapes::toArray($config); 
+    $config = Shapes::toArray($config);
     foreach ($data as $key => $value) {
       if (is_array($value)) {
         $value = new ImmVector($value);

--- a/tests/RootImporterTest.php
+++ b/tests/RootImporterTest.php
@@ -28,10 +28,12 @@ final class RootImporterTest extends BaseTestCase {
     $this->assertEmpty($importer->getFiles());
   }
 
-  public function provideTestModes(): array<(IncludedRoots, string)> {
+  public function provideTestModes(): array<(IncludedRoots, string, bool)> {
     return [
-      tuple(IncludedRoots::PROD_ONLY, 'test-prod.php'),
-      tuple(IncludedRoots::DEV_AND_PROD, 'test-dev.php'),
+      tuple(IncludedRoots::PROD_ONLY, 'test-prod.php', true),
+      tuple(IncludedRoots::PROD_ONLY, 'test-prod.php', false),
+      tuple(IncludedRoots::DEV_AND_PROD, 'test-dev.php', true),
+      tuple(IncludedRoots::DEV_AND_PROD, 'test-dev.php', false),
     ];
   }
 
@@ -39,13 +41,16 @@ final class RootImporterTest extends BaseTestCase {
   public function testImportTree(
     IncludedRoots $included_roots,
     string $test_file,
+    bool $relativeAutoloadRoot,
   ): void {
     $root = __DIR__.'/fixtures/hh-only';
     $builder = new RootImporter($root, $included_roots);
-    $tempfile = tempnam(sys_get_temp_dir(), 'hh_autoload');
+    $tempdir = $relativeAutoloadRoot ? $root.'/vendor' : sys_get_temp_dir();
+    $tempfile = tempnam($tempdir, 'hh_autoload');
     (new Writer())
       ->setBuilder($builder)
       ->setRoot($root)
+      ->setRelativeAutoloadRoot($relativeAutoloadRoot)
       ->writeToFile($tempfile);
 
     $cmd = (Vector {


### PR DESCRIPTION
Rather than using the root directoy at the time of building the autoload
map, use a path relative to `__DIR__`. If required, can instead revert
to the old behaviour of using an absolute path.

Fixes #10