### PR TITLE
Update PHPUnit dependency to 5.5.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,13 +5,13 @@
   "require": {
     "composer-plugin-api": "^1.0",
     "hhvm": "^3.12",
-    "91carriage/phpunit-hhi": "^5.1",
+    "91carriage/phpunit-hhi": "^5.5",
     "facebook/definition-finder": "^1.0",
     "fredemmott/hack-error-suppressor": "^1.0",
     "fredemmott/type-assert": "^1.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.1"
+    "phpunit/phpunit": "^5.5"
   },
   "autoload": {
     "classmap": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "491e8ef7ffd094df7f43fcde52495caf",
+    "content-hash": "cf1b9fefbc074150ef2817109d8f6a42",
     "packages": [
         {
             "name": "91carriage/phpunit-hhi",


### PR DESCRIPTION
phpunit-hhi 5.1-5.4 isn't actually compatible with hhvm-autoload; this commit is needed due to hack treating names as case sensitive:

https://git.simon.geek.nz/91-carriage/phpunit-hhi/commit/7e2cc2ca9a9a370485414f770ed90c819c783e7d

Bumping the version to the minimum tag that has that commit.