### PR TITLE
 Correctly handle underscores in classnames in PSR0Filter.

### DIFF
--- a/src/filters/PSR0Filter.php
+++ b/src/filters/PSR0Filter.php
@@ -18,6 +18,6 @@ final class PSR0Filter extends BasePSRFilter {
     string $prefix,
     string $root,
   ): string {
-    return $root.strtr($class_name, "\\", '/');
+    return $root.strtr($class_name, "\\_", '//');
   }
 }

--- a/src/filters/PSR0Filter.php
+++ b/src/filters/PSR0Filter.php
@@ -18,6 +18,17 @@ final class PSR0Filter extends BasePSRFilter {
     string $prefix,
     string $root,
   ): string {
-    return $root.strtr($class_name, "\\_", '//');
+    $class_name = strtr($class_name, '\\', '/');
+
+    // Underscores in namespace parts must be ignored, but those in the class
+    // name need to be converted.
+    $namespace = '';
+    if(($last_namespace_sep = strrpos($class_name, '/')) !== false) {
+      $namespace = substr($class_name, 0, $last_namespace_sep + 1);
+      $class_name = substr($class_name, $last_namespace_sep + 1);
+    }
+
+    return
+      $root . $namespace . strtr($class_name, '_', '/');
   }
 }

--- a/tests/ComposerImporterTest.php
+++ b/tests/ComposerImporterTest.php
@@ -232,4 +232,39 @@ final class ComposerImporterTest extends BaseTestCase {
       ),
     );
   }
+
+  /**
+   * @dataProvider getParsers
+   */
+  public function testPSR0ImportUnderscores(Parser $parser): void {
+    $root = realpath(__DIR__.'/fixtures/psr-0');
+    $composer = $root.'/composer.json';
+    $this->assertTrue(file_exists($composer));
+
+    $composer_config= json_decode(
+      file_get_contents($composer),
+      /* as array = */ true,
+    );
+
+    $importer = new ComposerImporter(
+      $composer,
+      shape(
+        'autoloadFilesBehavior' => AutoloadFilesBehavior::EXEC_FILES,
+        'includeVendor' => false,
+        'extraFiles' => ImmVector { },
+        'roots' => ImmVector { $root },
+        'devRoots' => ImmVector { },
+        'parser' => $parser,
+        'relativeAutoloadRoot' => true,
+      ),
+    );
+
+    $this->assertSame(
+      $root.'/src-with-underscores/PSR0_Test_With_Underscores/Foo/Bar.php',
+      idx(
+        $importer->getAutoloadMap()['class'],
+        'psr0_test_with_underscores\\foo_bar',
+      ),
+    );
+  }
 }

--- a/tests/fixtures/psr-0/composer.json
+++ b/tests/fixtures/psr-0/composer.json
@@ -2,7 +2,8 @@
   "autoload": {
     "psr-0": {
       "PSR0Test": "src",
-      "PSR0TestWithSlash": "src-with-slash"
+      "PSR0TestWithSlash": "src-with-slash",
+      "PSR0_Test_With_Underscores": "src-with-underscores"
     }
   }
 }

--- a/tests/fixtures/psr-0/src-with-underscores/PSR0_Test_With_Underscores/Foo/Bar.php
+++ b/tests/fixtures/psr-0/src-with-underscores/PSR0_Test_With_Underscores/Foo/Bar.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace PSR0_Test_With_Underscores;
+
+class Foo_Bar {};


### PR DESCRIPTION
This part of the PSR-0 spec was being ignored:

> Each _ character in the CLASS NAME is converted to a DIRECTORY_SEPARATOR. The _ character has no special meaning in the namespace.

Which means that a class Foo_Bar in Foo/Bar.php would be filtered out in BasePSRFilter because the expected file doesn't match the actual one, and the class is unreachable after switching to `hh_autoload.php`.