### PR TITLE
Add XHP support to HHClientFallbackHandler.

### DIFF
--- a/src/HHClientFallbackHandler.php
+++ b/src/HHClientFallbackHandler.php
@@ -118,7 +118,14 @@ class HHClientFallbackHandler extends FailureHandler {
   public function handleFailedType(string $name): void {
     $file = $this->lookupPath('class', $name);
     if ($file === null) {
-      $file = $this->lookupPath('typedef', $name);
+      if (substr($name, 0, 4) === 'xhp_') {
+        $xhp_name = ':'.str_replace(array('__', '_'), array(':', '-'), substr($name, 4));
+        $file = $this->lookupPath('class', $xhp_name);
+      }
+
+      if ($file === null) {
+        $file = $this->lookupPath('typedef', $name);
+      }
     }
 
     if ($file === null) {


### PR DESCRIPTION
`hh_client --search-class` only returns results for the "real" versions of XHP class (`:xhp`), but the fallback handler receives the mangled versions. They need to be unparsed in order to be actually loaded.