### PR TITLE
Add support for PSR-{0,4} fallback directories

### DIFF
--- a/src/filters/BasePSRFilter.php
+++ b/src/filters/BasePSRFilter.php
@@ -52,7 +52,7 @@ abstract class BasePSRFilter implements Builder {
     $classes =
       (new Map($this->source->getAutoloadMap()['class']))->filterWithKey(
         function(string $class_name, string $file): bool {
-          if (\stripos($class_name, $this->prefix) !== 0) {
+          if ($this->prefix !== '' && \stripos($class_name, $this->prefix) !== 0) {
             return false;
           }
           $expected = static::getExpectedPathWithoutExtension(

--- a/tests/ComposerImporterTest.php
+++ b/tests/ComposerImporterTest.php
@@ -10,6 +10,8 @@
 
 namespace Facebook\AutoloadMap;
 
+use function Facebook\FBExpect\expect;
+
 final class ComposerImporterTest extends BaseTestCase {
   /**
    * @dataProvider getParsers
@@ -166,15 +168,13 @@ final class ComposerImporterTest extends BaseTestCase {
   public function testPSR4ImportWithoutPrefix(Parser $parser): void {
     $root = \realpath(__DIR__.'/fixtures/psr-4');
     $composer = $root.'/composer.json';
-    $this->assertTrue(\file_exists($composer));
+    expect(\file_exists($composer))->toBeTrue();
 
     $composer_config = \json_decode(
       \file_get_contents($composer),
       /* as array = */ true,
     );
-    $this->assertNotEmpty(
-      $composer_config['autoload']['psr-4'],
-    );
+    expect($composer_config['autoload']['psr-4'])->toNotBeEmpty();
 
     $importer = new ComposerImporter(
       $composer,
@@ -191,12 +191,13 @@ final class ComposerImporterTest extends BaseTestCase {
       ),
     );
 
-    $this->assertSame(
-      $root.'/src-without-prefix/PSR4/TestWithoutPrefix/PSR4Test.php',
+    expect(
       idx(
         $importer->getAutoloadMap()['class'],
         'psr4\testwithoutprefix\psr4test',
       ),
+    )->toBeSame(
+      $root.'/src-without-prefix/PSR4/TestWithoutPrefix/PSR4Test.php',
     );
   }
 
@@ -327,12 +328,13 @@ final class ComposerImporterTest extends BaseTestCase {
   public function testPSR0ImportWithoutPrefix(Parser $parser): void {
     $root = \realpath(__DIR__.'/fixtures/psr-0');
     $composer = $root.'/composer.json';
-    $this->assertTrue(\file_exists($composer));
+    expect(\file_exists($composer))->toBeTrue();
 
     $composer_config = \json_decode(
       \file_get_contents($composer),
       /* as array = */ true,
     );
+    expect($composer_config['autoload']['psr-0'])->toNotBeEmpty();
 
     $importer = new ComposerImporter(
       $composer,
@@ -349,12 +351,13 @@ final class ComposerImporterTest extends BaseTestCase {
       ),
     );
 
-    $this->assertSame(
-      $root.'/src-without-prefix/PSR0TestWithoutPrefix.php',
+    expect(
       idx(
         $importer->getAutoloadMap()['class'],
         'psr0testwithoutprefix',
       ),
+    )->toBeSame(
+      $root.'/src-without-prefix/PSR0TestWithoutPrefix.php',
     );
   }
 }

--- a/tests/ComposerImporterTest.php
+++ b/tests/ComposerImporterTest.php
@@ -163,6 +163,46 @@ final class ComposerImporterTest extends BaseTestCase {
   /**
    * @dataProvider getParsers
    */
+  public function testPSR4ImportWithoutPrefix(Parser $parser): void {
+    $root = \realpath(__DIR__.'/fixtures/psr-4');
+    $composer = $root.'/composer.json';
+    $this->assertTrue(\file_exists($composer));
+
+    $composer_config = \json_decode(
+      \file_get_contents($composer),
+      /* as array = */ true,
+    );
+    $this->assertNotEmpty(
+      $composer_config['autoload']['psr-4'],
+    );
+
+    $importer = new ComposerImporter(
+      $composer,
+      shape(
+        'autoloadFilesBehavior' => AutoloadFilesBehavior::EXEC_FILES,
+        'includeVendor' => false,
+        'extraFiles' => ImmVector { },
+        'roots' => ImmVector { $root },
+        'devRoots' => ImmVector { },
+        'parser' => $parser,
+        'relativeAutoloadRoot' => true,
+        'failureHandler' => null,
+        'devFailureHandler' => null,
+      ),
+    );
+
+    $this->assertSame(
+      $root.'/src-without-prefix/PSR4/TestWithoutPrefix/PSR4Test.php',
+      idx(
+        $importer->getAutoloadMap()['class'],
+        'psr4\testwithoutprefix\psr4test',
+      ),
+    );
+  }
+
+  /**
+   * @dataProvider getParsers
+   */
   public function testPSR0Import(Parser $parser): void {
     $root = \realpath(__DIR__.'/fixtures/psr-0');
     $composer = $root.'/composer.json';
@@ -277,6 +317,43 @@ final class ComposerImporterTest extends BaseTestCase {
       idx(
         $importer->getAutoloadMap()['class'],
         'psr0_test_with_underscores\\foo_bar',
+      ),
+    );
+  }
+
+  /**
+   * @dataProvider getParsers
+   */
+  public function testPSR0ImportWithoutPrefix(Parser $parser): void {
+    $root = \realpath(__DIR__.'/fixtures/psr-0');
+    $composer = $root.'/composer.json';
+    $this->assertTrue(\file_exists($composer));
+
+    $composer_config = \json_decode(
+      \file_get_contents($composer),
+      /* as array = */ true,
+    );
+
+    $importer = new ComposerImporter(
+      $composer,
+      shape(
+        'autoloadFilesBehavior' => AutoloadFilesBehavior::EXEC_FILES,
+        'includeVendor' => false,
+        'extraFiles' => ImmVector {},
+        'roots' => ImmVector { $root },
+        'devRoots' => ImmVector {},
+        'parser' => $parser,
+        'relativeAutoloadRoot' => true,
+        'failureHandler' => null,
+        'devFailureHandler' => null,
+      ),
+    );
+
+    $this->assertSame(
+      $root.'/src-without-prefix/PSR0TestWithoutPrefix.php',
+      idx(
+        $importer->getAutoloadMap()['class'],
+        'psr0testwithoutprefix',
       ),
     );
   }

--- a/tests/RootImporterTest.php
+++ b/tests/RootImporterTest.php
@@ -20,7 +20,7 @@ final class RootImporterTest extends BaseTestCase {
       \array_keys($map['class']),
     );
 
-    $this->assertNotContains(
+    $this->assertContains(
       'phpunit_framework_testcase',
       \array_keys($map['class']),
     );

--- a/tests/RootImporterTest.php
+++ b/tests/RootImporterTest.php
@@ -20,7 +20,7 @@ final class RootImporterTest extends BaseTestCase {
       \array_keys($map['class']),
     );
 
-    $this->assertContains(
+    $this->assertNotContains(
       'phpunit_framework_testcase',
       \array_keys($map['class']),
     );

--- a/tests/fixtures/psr-0/composer.json
+++ b/tests/fixtures/psr-0/composer.json
@@ -1,6 +1,7 @@
 {
   "autoload": {
     "psr-0": {
+      "": "src-without-prefix",
       "PSR0Test": "src",
       "PSR0TestWithSlash": "src-with-slash",
       "PSR0_Test_With_Underscores": "src-with-underscores"

--- a/tests/fixtures/psr-0/src-without-prefix/PSR0TestWithoutPrefix.php
+++ b/tests/fixtures/psr-0/src-without-prefix/PSR0TestWithoutPrefix.php
@@ -1,0 +1,11 @@
+<?php
+/*
+ *  Copyright (c) 2015-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+class PSR0TestWithoutPrefix {}

--- a/tests/fixtures/psr-4/composer.json
+++ b/tests/fixtures/psr-4/composer.json
@@ -1,6 +1,7 @@
 {
   "autoload": {
     "psr-4": {
+      "": "src-without-prefix",
       "PSR4\\Test\\": "src",
       "PSR4\\TestWithSlash\\": "src-with-slash/"
     }

--- a/tests/fixtures/psr-4/src-without-prefix/PSR4/TestWithoutPrefix/PSR4Test.php
+++ b/tests/fixtures/psr-4/src-without-prefix/PSR4/TestWithoutPrefix/PSR4Test.php
@@ -1,0 +1,13 @@
+<?php
+/*
+ *  Copyright (c) 2015-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace PSR4\TestWithoutPrefix;
+
+class PSR4Test {}


### PR DESCRIPTION
[Composer allows for fallback directories](https://getcomposer.org/doc/04-schema.md#autoload) to be defined in PSR-{0,4} by providing an empty prefix, like so:
```json
{
    "autoload": {
        "psr-4": { "": "src/" }
    }
}
```

This PR updates `BasePSRFilter.php` (and related test coverage) to support this behavior.