### PR TITLE
use relative paths for require_once statement in generated autoload map

### DIFF
--- a/src/Writer.php
+++ b/src/Writer.php
@@ -166,7 +166,12 @@ final class Writer {
     $map = \var_export($map, true)
       |> \str_replace('array (', 'darray[', $$)
       |> \str_replace(')', ']', $$);
-    $autoload_map_typedef = \var_export(__DIR__.'/AutoloadMap.php', true);
+
+    if ($this->relativeAutoloadRoot) {
+      $autoload_map_typedef = '__DIR__.\'/../\'.'.\var_export($this->relativePath(__DIR__.'/AutoloadMap.php'), true);
+    } else {
+      $autoload_map_typedef = \var_export(__DIR__.'/AutoloadMap.php', true);
+    }
     $code = <<<EOF
 <?hh
 


### PR DESCRIPTION
Fixes #31 

## Before

`hh_autoload.hh` contained a line like this:
```
namespace Facebook\AutoloadMap\Generated;

require_once('/Users/path/to/fully/qualified/vendor/hhvm/hhvm-autoload/src/AutoloadMap.php');
```

The absolute path would happen even when the config setting to use relative paths was set, and broke some workflows that would build the map in a different place than where it was used.

## After

This fixes it to:
```
require_once(__DIR__.'/../'.'vendor/hhvm/hhvm-autoload/src/AutoloadMap.php');
```

Or for the case of `hhvm-autoload`'s own autoload map:
```
require_once(__DIR__.'/../'.'src/AutoloadMap.php');
```