### PR TITLE
Disallow array literal

### DIFF
--- a/.hhconfig
+++ b/.hhconfig
@@ -8,4 +8,6 @@ disallow_stringish_magic = true
 disable_primitive_refinement = true
 user_attributes=
 disable_static_local_variables = true
-disallow_array_literal = true
+
+; Once the minimum hhvm version hits 4.25 this setting can be safely enabled
+disallow_array_literal = false

--- a/.hhconfig
+++ b/.hhconfig
@@ -1,6 +1,6 @@
 assume_php=false
 enable_experimental_tc_features = no_fallback_in_namespaces, unpacking_check_arity, disallow_refs_in_array, disallow_untyped_lambda_as_non_function_type
-ignored_paths = [ "vendor/.+/tests/.+", "tests/fixtures/.+\.tmp\..+\.hack" ]
+ignored_paths = [ "vendor/.+/tests/.+", "vendor/.+/bin/.+", "tests/fixtures/.+\.tmp\..+\.hack" ]
 safe_array = true
 safe_vector_array = true
 disallow_destruct = true
@@ -8,3 +8,4 @@ disallow_stringish_magic = true
 disable_primitive_refinement = true
 user_attributes=
 disable_static_local_variables = true
+disallow_array_literal = true

--- a/src/ConfigurationLoader.hack
+++ b/src/ConfigurationLoader.hack
@@ -64,7 +64,7 @@ abstract final class ConfigurationLoader {
         TypeAssert\is_nullable_array_of_strings(
           $data['devRoots'] ?? null,
           'devRoots',
-        ) ?? [],
+        ) ?? varray[],
       ),
       'autoloadFilesBehavior' => TypeAssert\is_nullable_enum(
         AutoloadFilesBehavior::class,
@@ -83,7 +83,7 @@ abstract final class ConfigurationLoader {
         TypeAssert\is_nullable_array_of_strings(
           $data['extraFiles'] ?? null,
           'extraFiles',
-        ) ?? [],
+        ) ?? varray[],
       ),
       'parser' => TypeAssert\is_nullable_enum(
         Parser::class,

--- a/src/HHClientFallbackHandler.hack
+++ b/src/HHClientFallbackHandler.hack
@@ -148,7 +148,7 @@ class HHClientFallbackHandler extends FailureHandler {
     if ($file === null) {
       if (\substr($name, 0, 4) === 'xhp_') {
         $xhp_name =
-          ':'.\str_replace(array('__', '_'), array(':', '-'), \substr($name, 4));
+          ':'.\str_replace(varray['__', '_'], varray[':', '-'], \substr($name, 4));
         $file = $this->lookupPath('class', $xhp_name);
       }
 
@@ -224,7 +224,7 @@ class HHClientFallbackHandler extends FailureHandler {
     $cmd = \implode(' ', $cmd);
 
     $exit_code = null;
-    $output = array();
+    $output = varray[];
     $last = \exec($cmd, inout $output, inout $exit_code);
     if ($exit_code !== 0) {
       return null;

--- a/src/Merger.hack
+++ b/src/Merger.hack
@@ -39,7 +39,7 @@ abstract final class Merger {
   private static function mergeImpl(
     Iterable<array<string, string>> $maps,
   ): array<string, string> {
-    $out = [];
+    $out = darray[];
     foreach ($maps as $map) {
       foreach ($map as $def => $file) {
         $out[$def] = $file;

--- a/src/TypeAssert.hack
+++ b/src/TypeAssert.hack
@@ -61,7 +61,7 @@ function is_array_of_strings(
     '%s should be an array<string>',
     $field,
   );
-  $out = [];
+  $out = varray[];
   foreach ($value as $it) {
     invariant(
       $it is string,
@@ -86,7 +86,7 @@ function is_nullable_array_of_strings(
     '%s should be an ?array<string>',
     $field,
   );
-  $out = [];
+  $out = varray[];
   foreach ($value as $it) {
     invariant(
       $it is string,
@@ -124,7 +124,7 @@ function is_array_of_shapes_with_name_field(
   $msg = $field.
     'should be an array<shape(\'name\' => string)>';
   invariant(\is_array($value), '%s', $msg);
-  $out = [];
+  $out = varray[];
   foreach ($value as $it) {
     invariant(\is_array($it), '%s', $msg);
     $name = $it['name'] ?? null;

--- a/src/Writer.hack
+++ b/src/Writer.hack
@@ -162,7 +162,7 @@ final class Writer {
       $add_failure_handler = \sprintf(
         "if (%s::isEnabled()) {\n".
         "  \$handler = new %s();\n".
-        "  \$map['failure'] = [\$handler, 'handleFailure'];\n".
+        "  \$map['failure'] = varray[\$handler, 'handleFailure'];\n".
         "  \HH\autoload_set_paths(/* HH_FIXME[4110] */ \$map, Generated\\root());\n".
         "  \$handler->initialize();\n".
         "}",
@@ -244,7 +244,7 @@ function initialize(): void {
   \$map = Generated\\map();
 
   \HH\autoload_set_paths(/* HH_FIXME[4110] */ \$map, Generated\\root());
-  foreach (\spl_autoload_functions() ?: [] as \$autoloader) {
+  foreach (\spl_autoload_functions() ?: varray[] as \$autoloader) {
     \spl_autoload_unregister(\$autoloader);
   }
 

--- a/src/builders/ComposerImporter.hack
+++ b/src/builders/ComposerImporter.hack
@@ -136,7 +136,7 @@ final class ComposerImporter implements Builder {
   private static function normalizePSRRoots(
     array<string, mixed> $roots,
   ): array<string, array<string>> {
-    $out = [];
+    $out = darray[];
     foreach ($roots as $k => $v) {
       if ($v is string) {
         $out[$k][] = $v;

--- a/src/builders/FactParseScanner.hack
+++ b/src/builders/FactParseScanner.hack
@@ -30,7 +30,7 @@ final class FactParseScanner implements Builder {
       'FactsParse did not give us an array',
     );
 
-    $out = array();
+    $out = darray[];
     foreach ($data as $file => $facts) {
       invariant(
         \is_string($file),
@@ -122,10 +122,10 @@ final class FactParseScanner implements Builder {
     );
     $facts = self::untypedToShape($facts);
 
-    $classes = [];
-    $functions = [];
-    $types = [];
-    $constants = [];
+    $classes = darray[];
+    $functions = darray[];
+    $types = darray[];
+    $constants = darray[];
     foreach ($facts as $file => $file_facts) {
       foreach ($file_facts['types'] as $type) {
         $classes[\strtolower($type['name'])] = $file;

--- a/src/filters/BasePSRFilter.hack
+++ b/src/filters/BasePSRFilter.hack
@@ -67,9 +67,9 @@ abstract class BasePSRFilter implements Builder {
 
     return shape(
       'class' => $classes->toArray(),
-      'function' => [],
-      'type' => [],
-      'constant' => [],
+      'function' => darray[],
+      'type' => darray[],
+      'constant' => darray[],
     );
   }
 }

--- a/src/filters/ClassesOnlyFilter.hack
+++ b/src/filters/ClassesOnlyFilter.hack
@@ -27,9 +27,9 @@ final class ClassesOnlyFilter implements Builder {
   public function getAutoloadMap(): AutoloadMap {
     return shape(
       'class' => $this->source->getAutoloadMap()['class'],
-      'function' => [],
-      'type' => [],
-      'constant' => [],
+      'function' => darray[],
+      'type' => darray[],
+      'constant' => darray[],
     );
   }
 }

--- a/tests/BaseTest.hack
+++ b/tests/BaseTest.hack
@@ -11,7 +11,7 @@ namespace Facebook\AutoloadMap;
 
 abstract class BaseTest extends \Facebook\HackTest\HackTest {
   public function getParsers(): array<(Parser, classname<Builder>)> {
-    return [
+    return varray[
       tuple(Parser::EXT_FACTPARSE, FactParseScanner::class),
     ];
   }

--- a/tests/ConfigurationLoaderTest.hack
+++ b/tests/ConfigurationLoaderTest.hack
@@ -14,16 +14,16 @@ use function Facebook\FBExpect\expect;
 
 final class ConfigurationLoaderTest extends \Facebook\HackTest\HackTest {
   public function goodTestCases(): array<string, array<array<string, mixed>>> {
-    return [
-      'fully specified' => [[
+    return darray[
+      'fully specified' => varray[darray[
         'autoloadFilesBehavior' => AutoloadFilesBehavior::EXEC_FILES,
         'relativeAutoloadRoot' => false,
         'includeVendor' => false,
-        'extraFiles' => [],
-        'roots' => ['foo/', 'bar/'],
+        'extraFiles' => varray[],
+        'roots' => varray['foo/', 'bar/'],
         'parser' => 'ext-factparse',
       ]],
-      'just roots' => [['roots' => ['foo/', 'bar/']]],
+      'just roots' => varray[darray['roots' => varray['foo/', 'bar/']]],
     ];
   }
 

--- a/tests/RootImporterTest.hack
+++ b/tests/RootImporterTest.hack
@@ -28,7 +28,7 @@ final class RootImporterTest extends BaseTest {
   }
 
   public function provideTestModes(): array<(IncludedRoots, string, bool)> {
-    return [
+    return varray[
       tuple(IncludedRoots::PROD_ONLY, 'test-prod.php', true),
       tuple(IncludedRoots::PROD_ONLY, 'test-prod.php', false),
       tuple(IncludedRoots::DEV_AND_PROD, 'test-dev.php', true),
@@ -64,7 +64,7 @@ final class RootImporterTest extends BaseTest {
     )->map($x ==> \escapeshellarg($x));
     $cmd = \implode(' ', $cmd);
 
-    $output = [];
+    $output = varray[];
     $exit_code = null;
     $result = \exec($cmd, inout $output, inout $exit_code);
 

--- a/tests/ScannerTest.hack
+++ b/tests/ScannerTest.hack
@@ -26,7 +26,7 @@ final class ScannerTest extends BaseTest {
     )->getAutoloadMap();
 
     $this->assertMapMatches(
-      [
+      darray[
         'ExampleClassInHH' => 'class_in_hh.hh',
         'ExampleClass' => 'class.php',
         'ExampleEnum' => 'enum.php',
@@ -36,12 +36,12 @@ final class ScannerTest extends BaseTest {
     );
 
     $this->assertMapMatches(
-      [ 'example_function' => 'function.php' ],
+      darray[ 'example_function' => 'function.php' ],
       $map['function'],
     );
 
     $this->assertMapMatches(
-      [
+      darray[
         'ExampleType' => 'type.php',
         'ExampleNewtype' => 'newtype.php',
       ],
@@ -49,7 +49,7 @@ final class ScannerTest extends BaseTest {
     );
 
     $this->assertMapMatches(
-      [
+      darray[
         'FREDEMMOTT_AUTOLOAD_MAP_TEST_FIXTURES_EXAMPLE_CONSTANT'
           => 'constant.php',
       ],
@@ -84,7 +84,7 @@ final class ScannerTest extends BaseTest {
     expect($map['function'])->toBeEmpty();
     expect($map['type'])->toBeEmpty();
     $this->assertMapMatches(
-      [
+      darray[
         'FREDEMMOTT_AUTOLOAD_MAP_TEST_FIXTURES_EXAMPLE_CONSTANT'
           => 'constant.php',
       ],


### PR DESCRIPTION
I want to enable this setting in my project to discourage the use of plain php arrays.

This requires that all the dependencies also meet the `disallow_array_literal` requirement.

I replaced all `array(...)` and `[...]` expressions with their darray/varray counterpart.