### PR TITLE
Strip PHP from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Usage
 
 1. Add an `hh_autoload.json` file (see section below) and optionally remove your configuration from composer.json
 2. `composer require hhvm/hhvm-autoload`
-3. Replace any references to `vendor/autoload.php` with  `vendor/hh_autoload.hack` and call `Facebook\AutoloadMap\initialize()`
+3. Replace any references to `vendor/autoload.php` with  `vendor/autoload.hack` and call `Facebook\AutoloadMap\initialize()`
 4. To re-generate the map, run `vendor/bin/hh-autoload`, `composer dump-autoload`, or any other command that generates the map
 
 Configuration (`hh_autoload.json`)
@@ -25,9 +25,9 @@ This will look for autoloadable definitions in `src/`, and also look in `vendor/
 
 The following settings are optional:
 
- - `"extraFiles": ["file1.hack"]` - files that should not be autoloaded, but should be `require()`ed by `vendor/hh_autoload.hh`. This should be needed much less frequently than under Composer
- - `"includeVendor": false` - do not include `vendor/` definitions in `vendor/hh_autoload.hh`
- - `"autoloadFilesBehavior": "scan"|"exec"` - whether autoload `files` from vendor should be `scan`ned for definitions, or `exec`uted by `vendor/hh_autoload.hh` - `scan` is the default, and generally favorable, but `exec` is needed if you have dependencies that need code to be executed on startup. `scan` is sufficient if your dependencies just use `files` because they need to define things that aren't classes, which is usually the case.
+ - `"extraFiles": ["file1.hack"]` - files that should not be autoloaded, but should be `require()`ed by `vendor/autoload.hack`. This should be needed much less frequently than under Composer
+ - `"includeVendor": false` - do not include `vendor/` definitions in `vendor/autoload.hack`
+ - `"autoloadFilesBehavior": "scan"|"exec"` - whether autoload `files` from vendor should be `scan`ned for definitions, or `exec`uted by `vendor/autoload.hack` - `scan` is the default, and generally favorable, but `exec` is needed if you have dependencies that need code to be executed on startup. `scan` is sufficient if your dependencies just use `files` because they need to define things that aren't classes, which is usually the case.
  - `"devRoots": [ "path/", ...]` - additional roots to only include in dev mode, not when installed as a dependency.
  - `"relativeAutoloadRoot": false` - do not use a path relative to `__DIR__` for autoloading. Instead, use the path to the folder containing `hh_autoload.json` when building the autoload map.
  - `"failureHandler:" classname<Facebook\AutoloadMap\FailureHandler>` - use the specified class to handle definitions that aren't the Map. Your handler will not be invoked for functions or constants

--- a/README.md
+++ b/README.md
@@ -1,36 +1,14 @@
 HHVM-Autoload [![Build Status](https://travis-ci.org/hhvm/hhvm-autoload.svg?branch=master)](https://travis-ci.org/hhvm/hhvm-autoload)
 =============
-A Composer plugin for autoloading classes, enums, functions, typedefs, and constants on HHVM.
-
-FAQ
-===
-
-Do I need to use Hack?
-----------------------
-
-No, PHP is fine - but HHVM is required because:
-
- - PHP does not support autoloading anything other than classes
- - this project and the parser are written in Hack
-
-Can I autoload functions and constants if I'm not writing Hack?
----------------------------------------------------------------
-
-Yes :)
-
-Why does this project use Composer's autoloader?
-------------------------------------------------
-
-It can't depend on itself :)
+The autoloader for autoloading classes, enums, functions, typedefs, and constants on HHVM.
 
 Usage
 =====
 
 1. Add an `hh_autoload.json` file (see section below) and optionally remove your configuration from composer.json
 2. `composer require hhvm/hhvm-autoload`
-3. Replace any references to `vendor/autoload.php` with  `vendor/hh_autoload.hh`
-4. If you are using PHPUnit, you will need to add `vendor/hh_autoload.hh` to your `bootstrap.php`, or to `phpunit.xml` as a `bootstrap` file if you don't already have one. This is because PHPUnit automatically loads `vendor/autoload.php`, but is not aware of `vendor/hh_autoload.hh`
-5. To re-generate the map, run `vendor/bin/hh-autoload`, `composer dump-autoload`, or any other command that generates the map
+3. Replace any references to `vendor/autoload.php` with  `vendor/hh_autoload.hack` and call `Facebook\AutoloadMap\initialize()`
+4. To re-generate the map, run `vendor/bin/hh-autoload`, `composer dump-autoload`, or any other command that generates the map
 
 Configuration (`hh_autoload.json`)
 ==================================
@@ -47,7 +25,7 @@ This will look for autoloadable definitions in `src/`, and also look in `vendor/
 
 The following settings are optional:
 
- - `"extraFiles": ["file1.php"]` - files that should not be autoloaded, but should be `require()`ed by `vendor/hh_autoload.hh`. This should be needed much less frequently than under Composer
+ - `"extraFiles": ["file1.hack"]` - files that should not be autoloaded, but should be `require()`ed by `vendor/hh_autoload.hh`. This should be needed much less frequently than under Composer
  - `"includeVendor": false` - do not include `vendor/` definitions in `vendor/hh_autoload.hh`
  - `"autoloadFilesBehavior": "scan"|"exec"` - whether autoload `files` from vendor should be `scan`ned for definitions, or `exec`uted by `vendor/hh_autoload.hh` - `scan` is the default, and generally favorable, but `exec` is needed if you have dependencies that need code to be executed on startup. `scan` is sufficient if your dependencies just use `files` because they need to define things that aren't classes, which is usually the case.
  - `"devRoots": [ "path/", ...]` - additional roots to only include in dev mode, not when installed as a dependency.
@@ -96,10 +74,6 @@ following additional behaviors:
 
 You can override these behaviors in a subclass.
 
-As it is based on `hh_client`, it is unable to handle PHP definitions -
-however, if you're using composer, changes to your PHP dependencies will
-automatically trigger a map rebuild.
-
 Custom Handlers
 ---------------
 
@@ -117,11 +91,9 @@ Information you may need is available from:
 How It Works
 ============
 
- - A parser (FactParse or DefinitionFinder) provides a list of all PHP and Hack definitions in the specified locations
+ - A parser (FactParse or DefinitionFinder) provides a list of all Hack definitions in the specified locations
  - This is used to generate something similar to a classmap, except including other kinds of definitions
  - The map is provided to HHVM with [`HH\autoload_set_paths()`](https://docs.hhvm.com/hack/reference/function/HH.autoload_set_paths/)
-
-The [Composer plugin API](https://getcomposer.org/doc/articles/plugins.md) allows it to re-generate the `vendor/hh_autoload.hh` file automatically whenever Composer itself regenerates `vendor/autoload.php`
 
 Contributing
 ============


### PR DESCRIPTION
We don't target real PHP files since HHVM4.0.