### PR TITLE
Upgrade to hack arrays

### DIFF
--- a/bin/hh-autoload.hack
+++ b/bin/hh-autoload.hack
@@ -56,11 +56,11 @@ final class GenerateScript {
       /* use_threads = */ true,
     );
 
-    $map = darray[
-      'class' => darray[],
-      'function' => darray[],
-      'type' => darray[],
-      'constant' => darray[],
+    $map = dict[
+      'class' => dict[],
+      'function' => dict[],
+      'type' => dict[],
+      'constant' => dict[],
     ];
 
     foreach ($facts as $path => $file_facts) {
@@ -128,9 +128,7 @@ final class GenerateScript {
   private static function generateAutoloader(self::TOptions $options): void {
     $importer = new RootImporter(
       \getcwd(),
-      $options['dev']
-        ? IncludedRoots::DEV_AND_PROD
-        : IncludedRoots::PROD_ONLY,
+      $options['dev'] ? IncludedRoots::DEV_AND_PROD : IncludedRoots::PROD_ONLY,
     );
 
     $handler = $options['dev']
@@ -147,10 +145,7 @@ final class GenerateScript {
     print(\getcwd()."/vendor/autoload.hack\n");
   }
 
-  private static function printUsage(
-    resource $to,
-    string $bin,
-  ): void {
+  private static function printUsage(resource $to, string $bin): void {
     \fprintf($to, "USAGE: %s [--no-dev]\n", $bin);
   }
 

--- a/src/AutoloadMap.hack
+++ b/src/AutoloadMap.hack
@@ -12,15 +12,5 @@ namespace Facebook\AutoloadMap;
 /** The main shape of an autoload map.
  *
  * Must match `\HH\autoload_set_paths()`
- * However, this is nolonger accurate.
- * The parameter of autoload_set_paths is a
- * `KeyedContainer<string, KeyedContainer<string, string>>`.
- * This does sadly not allow for the fallback key,
- * which is a (function(string, string): bool).
  */
-type AutoloadMap = shape(
-  'class' => darray<string, string>,
-  'function' => darray<string, string>,
-  'type' => darray<string, string>,
-  'constant' => darray<string, string>,
-);
+type AutoloadMap = dict<string, dict<string, string>>;

--- a/src/Config.hack
+++ b/src/Config.hack
@@ -11,10 +11,10 @@ namespace Facebook\AutoloadMap;
 
 /** Shape of `hh_autoload.json` */
 type Config = shape(
-  'roots' => ImmVector<string>,
-  'devRoots' => ImmVector<string>,
+  'roots' => vec<string>,
+  'devRoots' => vec<string>,
   'includeVendor' => bool,
-  'extraFiles' => ImmVector<string>,
+  'extraFiles' => vec<string>,
   'parser' => Parser,
   'failureHandler' => ?string,
   'devFailureHandler' => ?string,

--- a/src/ConfigurationLoader.hack
+++ b/src/ConfigurationLoader.hack
@@ -52,14 +52,12 @@ abstract final class ConfigurationLoader {
 
     return shape(
       'roots' =>
-        vec(TypeAssert\is_array_of_strings($data['roots'] ?? null, 'roots')),
-      'devRoots' => vec(
-        TypeAssert\is_nullable_array_of_strings(
-          $data['devRoots'] ?? null,
-          'devRoots',
-        ) ??
-          vec[],
-      ),
+        TypeAssert\is_vec_like_of_strings($data['roots'] ?? null, 'roots'),
+      'devRoots' => TypeAssert\is_nullable_vec_like_of_strings(
+        $data['devRoots'] ?? null,
+        'devRoots',
+      ) ??
+        vec[],
       'relativeAutoloadRoot' => TypeAssert\is_nullable_bool(
         $data['relativeAutoloadRoot'] ?? null,
         'relativerAutoloadRoot',
@@ -70,13 +68,11 @@ abstract final class ConfigurationLoader {
         'includeVendor',
       ) ??
         true,
-      'extraFiles' => vec(
-        TypeAssert\is_nullable_array_of_strings(
-          $data['extraFiles'] ?? null,
-          'extraFiles',
-        ) ??
-          vec[],
-      ),
+      'extraFiles' => TypeAssert\is_nullable_vec_like_of_strings(
+        $data['extraFiles'] ?? null,
+        'extraFiles',
+      ) ??
+        vec[],
       'parser' => TypeAssert\is_nullable_enum(
         Parser::class,
         $data['parser'] ?? null,

--- a/src/ConfigurationLoader.hack
+++ b/src/ConfigurationLoader.hack
@@ -51,14 +51,14 @@ abstract final class ConfigurationLoader {
     );
 
     return shape(
-      'roots' => new ImmVector(
-        TypeAssert\is_array_of_strings($data['roots'] ?? null, 'roots'),
-      ),
-      'devRoots' => new ImmVector(
+      'roots' =>
+        vec(TypeAssert\is_array_of_strings($data['roots'] ?? null, 'roots')),
+      'devRoots' => vec(
         TypeAssert\is_nullable_array_of_strings(
           $data['devRoots'] ?? null,
           'devRoots',
-        ),
+        ) ??
+          vec[],
       ),
       'relativeAutoloadRoot' => TypeAssert\is_nullable_bool(
         $data['relativeAutoloadRoot'] ?? null,
@@ -70,11 +70,12 @@ abstract final class ConfigurationLoader {
         'includeVendor',
       ) ??
         true,
-      'extraFiles' => new ImmVector(
+      'extraFiles' => vec(
         TypeAssert\is_nullable_array_of_strings(
           $data['extraFiles'] ?? null,
           'extraFiles',
-        ),
+        ) ??
+          vec[],
       ),
       'parser' => TypeAssert\is_nullable_enum(
         Parser::class,

--- a/src/HHClientFallbackHandler.hack
+++ b/src/HHClientFallbackHandler.hack
@@ -9,7 +9,7 @@
 
 namespace Facebook\AutoloadMap;
 
-use namespace HH\Lib\C;
+use namespace HH\Lib\{C, Str};
 
 /**
  * If a class/function/type isn't in the map, ask `hh_client` where it is.
@@ -146,9 +146,9 @@ class HHClientFallbackHandler extends FailureHandler {
   public function handleFailedType(string $name): void {
     $file = $this->lookupPath('class', $name);
     if ($file === null) {
-      if (\substr($name, 0, 4) === 'xhp_') {
+      if (Str\slice($name, 0, 4) === 'xhp_') {
         $xhp_name = ':'.
-          \str_replace(varray['__', '_'], varray[':', '-'], \substr($name, 4));
+          Str\replace_every(Str\slice($name, 4), dict['__' => ':', '_' => '-']);
         $file = $this->lookupPath('class', $xhp_name);
       }
 
@@ -224,8 +224,8 @@ class HHClientFallbackHandler extends FailureHandler {
     $cmd = \implode(' ', $cmd);
 
     $exit_code = null;
-    $output = varray[];
-    $last = \exec($cmd, inout $output, inout $exit_code);
+    $_output = varray[];
+    $last = \exec($cmd, inout $_output, inout $exit_code);
     if ($exit_code !== 0) {
       return null;
     }

--- a/src/HHClientFallbackHandler.hack
+++ b/src/HHClientFallbackHandler.hack
@@ -9,7 +9,7 @@
 
 namespace Facebook\AutoloadMap;
 
-use namespace HH\Lib\{C, Str};
+use namespace HH\Lib\{C, Str, Vec};
 
 /**
  * If a class/function/type isn't in the map, ask `hh_client` where it is.
@@ -132,7 +132,7 @@ class HHClientFallbackHandler extends FailureHandler {
       return false;
     }
 
-    $killswitches = ImmSet {'CI', 'TRAVIS', 'CONTINUOUS_INTEGRATION'};
+    $killswitches = vec['CI', 'TRAVIS', 'CONTINUOUS_INTEGRATION'];
     foreach ($killswitches as $killswitch) {
       $env = \getenv($killswitch);
       if ($env === 'true' || $env === '1') {
@@ -218,7 +218,8 @@ class HHClientFallbackHandler extends FailureHandler {
   }
 
   private function lookupPathImpl(string $kind, string $name): ?string {
-    $cmd = (ImmVector {'hh_client', '--json', '--search-'.$kind, $name})->map(
+    $cmd = Vec\map(
+      vec['hh_client', '--json', '--search-'.$kind, $name],
       $x ==> \escapeshellarg($x),
     );
     $cmd = \implode(' ', $cmd);

--- a/src/HHClientFallbackHandler.hack
+++ b/src/HHClientFallbackHandler.hack
@@ -132,7 +132,7 @@ class HHClientFallbackHandler extends FailureHandler {
       return false;
     }
 
-    $killswitches = vec['CI', 'TRAVIS', 'CONTINUOUS_INTEGRATION'];
+    $killswitches = keyset['CI', 'TRAVIS', 'CONTINUOUS_INTEGRATION'];
     foreach ($killswitches as $killswitch) {
       $env = \getenv($killswitch);
       if ($env === 'true' || $env === '1') {

--- a/src/Merger.hack
+++ b/src/Merger.hack
@@ -23,18 +23,18 @@ abstract final class Merger {
    * In the case of duplicates, the last definition is used.
    */
   public static function merge(vec<AutoloadMap> $maps): AutoloadMap {
-    return shape(
+    return dict[
       'class' => self::mergeImpl(Vec\map($maps, $map ==> $map['class'])),
       'function' => self::mergeImpl(Vec\map($maps, $map ==> $map['function'])),
       'type' => self::mergeImpl(Vec\map($maps, $map ==> $map['type'])),
       'constant' => self::mergeImpl(Vec\map($maps, $map ==> $map['constant'])),
-    );
+    ];
   }
 
   private static function mergeImpl(
     Traversable<KeyedTraversable<string, string>> $maps,
-  ): darray<string, string> {
-    $out = darray[];
+  ): dict<string, string> {
+    $out = dict[];
     foreach ($maps as $map) {
       foreach ($map as $def => $file) {
         $out[$def] = $file;

--- a/src/Merger.hack
+++ b/src/Merger.hack
@@ -30,7 +30,7 @@ abstract final class Merger {
   }
 
   private static function mergeImpl(
-    Traversable<darray<string, string>> $maps,
+    Traversable<KeyedTraversable<string, string>> $maps,
   ): darray<string, string> {
     $out = darray[];
     foreach ($maps as $map) {

--- a/src/Merger.hack
+++ b/src/Merger.hack
@@ -9,6 +9,8 @@
 
 namespace Facebook\AutoloadMap;
 
+use namespace HH\Lib\Vec;
+
 /** Class for merging multiple autoload maps.
  *
  * For example, we may merge:
@@ -20,12 +22,12 @@ abstract final class Merger {
    *
    * In the case of duplicates, the last definition is used.
    */
-  public static function merge(\ConstVector<AutoloadMap> $maps): AutoloadMap {
+  public static function merge(vec<AutoloadMap> $maps): AutoloadMap {
     return shape(
-      'class' => self::mergeImpl($maps->map($map ==> $map['class'])),
-      'function' => self::mergeImpl($maps->map($map ==> $map['function'])),
-      'type' => self::mergeImpl($maps->map($map ==> $map['type'])),
-      'constant' => self::mergeImpl($maps->map($map ==> $map['constant'])),
+      'class' => self::mergeImpl(Vec\map($maps, $map ==> $map['class'])),
+      'function' => self::mergeImpl(Vec\map($maps, $map ==> $map['function'])),
+      'type' => self::mergeImpl(Vec\map($maps, $map ==> $map['type'])),
+      'constant' => self::mergeImpl(Vec\map($maps, $map ==> $map['constant'])),
     );
   }
 

--- a/src/TypeAssert.hack
+++ b/src/TypeAssert.hack
@@ -41,18 +41,36 @@ function is_array_of_strings(mixed $value, string $field): array<string> {
   return $out;
 }
 
-function is_nullable_array_of_strings(
+function is_vec_like_of_strings(mixed $value, string $field): vec<string> {
+  invariant(
+    $value is vec<_> || \is_array($value),
+    '%s should be a vec<string>',
+    $field,
+  );
+  $out = vec[];
+  foreach ($value as $el) {
+    invariant($el is string, '%s should be a vec<string>', $field);
+    $out[] = $el;
+  }
+  return $out;
+}
+
+function is_nullable_vec_like_of_strings(
   mixed $value,
   string $field,
-): ?array<string> {
+): ?vec<string> {
   if ($value === null) {
     return null;
   }
 
-  invariant(\is_array($value), '%s should be an ?array<string>', $field);
-  $out = varray[];
+  invariant(
+    \is_array($value) || $value is vec<_>,
+    '%s should be an ?vec<string>',
+    $field,
+  );
+  $out = vec[];
   foreach ($value as $it) {
-    invariant($it is string, '%s should be an ?array<string>', $field);
+    invariant($it is string, '%s should be an ?vec<string>', $field);
     $out[] = $it;
   }
   return $out;

--- a/src/Writer.hack
+++ b/src/Writer.hack
@@ -137,10 +137,13 @@ final class Writer {
 
     $map = \array_map(
       ($sub_map): mixed ==> {
-        assert(\is_array($sub_map));
-        return \array_map($path ==> $this->relativePath($path), $sub_map);
+        assert($sub_map is KeyedContainer<_, _>);
+        return \array_map(
+          $path ==> $this->relativePath($path as string),
+          $sub_map,
+        );
       },
-      Shapes::toArray($map),
+      $map,
     );
 
     $failure_handler = $this->failureHandler;
@@ -171,7 +174,7 @@ final class Writer {
     );
 
     $map = \var_export($map, true)
-      |> \str_replace('array (', 'darray[', $$)
+      |> \str_replace('array (', 'dict[', $$)
       |> \str_replace(')', ']', $$);
 
     if ($this->relativeAutoloadRoot) {

--- a/src/Writer.hack
+++ b/src/Writer.hack
@@ -237,7 +237,7 @@ function initialize(): void {
   \$map = Generated\\map();
 
   \HH\autoload_set_paths(/* HH_FIXME[4110] incorrect hhi */ \$map, Generated\\root());
-  foreach (\spl_autoload_functions() ?: varray[] as \$autoloader) {
+  foreach (\spl_autoload_functions() ?: vec[] as \$autoloader) {
     \spl_autoload_unregister(\$autoloader);
   }
 

--- a/src/Writer.hack
+++ b/src/Writer.hack
@@ -9,7 +9,7 @@
 
 namespace Facebook\AutoloadMap;
 
-use namespace HH\Lib\Str;
+use namespace HH\Lib\{Str, Vec};
 
 /** Class to write `autoload.hack`.
  *
@@ -20,7 +20,7 @@ use namespace HH\Lib\Str;
  * - the failure handler
  */
 final class Writer {
-  private ?ImmVector<string> $files;
+  private ?vec<string> $files;
   private ?AutoloadMap $map;
   private ?string $root;
   private bool $relativeAutoloadRoot = true;
@@ -44,7 +44,7 @@ final class Writer {
   }
 
   /** Files to explicitly include */
-  public function setFiles(ImmVector<string> $files): this {
+  public function setFiles(vec<string> $files): this {
     $this->files = $files;
     return $this;
   }
@@ -117,20 +117,22 @@ final class Writer {
 
     if ($this->relativeAutoloadRoot) {
       $root = '__DIR__.\'/../\'';
-      $requires = $files->map(
+      $requires = Vec\map(
+        $files,
         $file ==>
           '__DIR__.'.\var_export('/../'.$this->relativePath($file), true),
       );
     } else {
       $root = \var_export($this->root.'/', true);
-      $requires = $files->map(
+      $requires = Vec\map(
+        $files,
         $file ==> \var_export($this->root.'/'.$this->relativePath($file), true),
       );
     }
 
     $requires = \implode(
       "\n",
-      $requires->map($require ==> 'require_once('.$require.');'),
+      Vec\map($requires, $require ==> 'require_once('.$require.');'),
     );
 
     $map = \array_map(

--- a/src/builders/Builder.hack
+++ b/src/builders/Builder.hack
@@ -17,5 +17,5 @@ interface Builder {
   public function getAutoloadMap(): AutoloadMap;
   /** Returns any additional files that should be explicitly required on
    * start */
-  public function getFiles(): ImmVector<string>;
+  public function getFiles(): vec<string>;
 }

--- a/src/builders/FactParseScanner.hack
+++ b/src/builders/FactParseScanner.hack
@@ -113,10 +113,10 @@ final class FactParseScanner implements Builder {
     );
     $facts = self::untypedToShape($facts);
 
-    $classes = darray[];
-    $functions = darray[];
-    $types = darray[];
-    $constants = darray[];
+    $classes = dict[];
+    $functions = dict[];
+    $types = dict[];
+    $constants = dict[];
     foreach ($facts as $file => $file_facts) {
       foreach ($file_facts['types'] as $type) {
         $classes[\strtolower($type['name'])] = $file;
@@ -131,12 +131,12 @@ final class FactParseScanner implements Builder {
         $types[\strtolower($alias)] = $file;
       }
     }
-    return shape(
+    return dict[
       'class' => $classes,
       'function' => $functions,
       'type' => $types,
       'constant' => $constants,
-    );
+    ];
   }
 
   public function getFiles(): vec<string> {

--- a/src/builders/FactParseScanner.hack
+++ b/src/builders/FactParseScanner.hack
@@ -63,7 +63,7 @@ final class FactParseScanner implements Builder {
 
   private function __construct(
     private string $root,
-    private ImmVector<string> $paths,
+    private vec<string> $paths,
   ) {
     $version = (int)\phpversion('factparse');
     invariant(
@@ -74,11 +74,11 @@ final class FactParseScanner implements Builder {
   }
 
   public static function fromFile(string $path): Builder {
-    return new FactParseScanner('', ImmVector {$path});
+    return new FactParseScanner('', vec[$path]);
   }
 
   public static function fromTree(string $root): Builder {
-    $paths = Vector {};
+    $paths = vec[];
     $rdi = new \RecursiveDirectoryIterator($root);
     $rii = new \RecursiveIteratorIterator($rdi);
     foreach ($rii as $info) {
@@ -101,13 +101,13 @@ final class FactParseScanner implements Builder {
       $paths[] = $info->getPathname();
     }
 
-    return new FactParseScanner($root, $paths->immutable());
+    return new FactParseScanner($root, $paths);
   }
 
   public function getAutoloadMap(): AutoloadMap {
     $facts = \HH\facts_parse(
       $this->root,
-      $this->paths->toValuesArray(),
+      varray($this->paths),
       /* force_hh = */ false,
       /* multithreaded = */ true,
     );
@@ -139,7 +139,7 @@ final class FactParseScanner implements Builder {
     );
   }
 
-  public function getFiles(): ImmVector<string> {
-    return ImmVector {};
+  public function getFiles(): vec<string> {
+    return vec[];
   }
 }

--- a/src/builders/HHImporter.hack
+++ b/src/builders/HHImporter.hack
@@ -83,7 +83,7 @@ final class HHImporter implements Builder {
 
   public function getAutoloadMap(): AutoloadMap {
     return Merger::merge(
-      $this->builders->map($builder ==> $builder->getAutoloadMap()),
+      Vec\map($this->builders, $builder ==> $builder->getAutoloadMap()),
     );
   }
 

--- a/src/builders/HHImporter.hack
+++ b/src/builders/HHImporter.hack
@@ -18,8 +18,8 @@ use namespace HH\Lib\Vec;
  * `vendor/` that are designed for use with `hhvm-autoload`.
  */
 final class HHImporter implements Builder {
-  private Vector<Builder> $builders = Vector {};
-  private Vector<string> $files = Vector {};
+  private vec<Builder> $builders = vec[];
+  private vec<string> $files = vec[];
   private Config $config;
 
   public function __construct(string $root, IncludedRoots $included_roots) {

--- a/src/builders/HHImporter.hack
+++ b/src/builders/HHImporter.hack
@@ -9,6 +9,8 @@
 
 namespace Facebook\AutoloadMap;
 
+use namespace HH\Lib\Vec;
+
 /** Create an autoload map for a directory that contains an
  * `hh_autoload.json`.
  *
@@ -23,10 +25,11 @@ final class HHImporter implements Builder {
   public function __construct(string $root, IncludedRoots $included_roots) {
     $config_file = $root.'/hh_autoload.json';
     if (!\file_exists($config_file)) {
-      $roots = (ImmVector {'src', 'lib'})
-        ->filter($x ==> \is_dir($root.'/'.$x));
-      $dev_roots = (ImmVector {'test', 'tests', 'examples', 'example'})
-        ->filter($x ==> \is_dir($root.'/'.$x));
+      $roots = Vec\filter(vec['src', 'lib'], $x ==> \is_dir($root.'/'.$x));
+      $dev_roots = Vec\filter(
+        vec['test', 'tests', 'examples', 'example'],
+        $x ==> \is_dir($root.'/'.$x),
+      );
       \file_put_contents(
         $config_file,
         \json_encode(
@@ -59,7 +62,7 @@ final class HHImporter implements Builder {
         $roots = $config['roots'];
         break;
       case IncludedRoots::DEV_AND_PROD:
-        $roots = $config['roots']->concat($config['devRoots']);
+        $roots = Vec\concat($config['roots'], $config['devRoots']);
         break;
     }
 
@@ -84,13 +87,10 @@ final class HHImporter implements Builder {
     );
   }
 
-  public function getFiles(): ImmVector<string> {
-    $files = Vector {};
-    $files->addAll($this->files);
-    foreach ($this->builders as $builder) {
-      $files->addAll($builder->getFiles());
-    }
-    return $files->toImmVector();
+  public function getFiles(): vec<string> {
+    return Vec\map($this->builders, $builder ==> $builder->getFiles())
+      |> Vec\concat(vec[$this->files], $$)
+      |> Vec\flatten($$);
   }
 
   public function getConfig(): Config {

--- a/src/builders/RootImporter.hack
+++ b/src/builders/RootImporter.hack
@@ -50,7 +50,7 @@ final class RootImporter implements Builder {
 
   public function getAutoloadMap(): AutoloadMap {
     return Merger::merge(
-      $this->builders->map($builder ==> $builder->getAutoloadMap()),
+      Vec\map($this->builders, $builder ==> $builder->getAutoloadMap()),
     );
   }
 

--- a/src/builders/RootImporter.hack
+++ b/src/builders/RootImporter.hack
@@ -9,6 +9,8 @@
 
 namespace Facebook\AutoloadMap;
 
+use namespace HH\Lib\Vec;
+
 /** Build an autoload map for the project root.
  *
  * This will:
@@ -52,12 +54,9 @@ final class RootImporter implements Builder {
     );
   }
 
-  public function getFiles(): ImmVector<string> {
-    $files = Vector {};
-    foreach ($this->builders as $builder) {
-      $files->addAll($builder->getFiles());
-    }
-    return $files->toImmVector();
+  public function getFiles(): vec<string> {
+    return Vec\map($this->builders, $builder ==> $builder->getFiles())
+      |> Vec\flatten($$);
   }
 
   public function getConfig(): Config {

--- a/src/builders/RootImporter.hack
+++ b/src/builders/RootImporter.hack
@@ -23,7 +23,7 @@ use namespace HH\Lib\Vec;
  * mostly applied to PHP files which HHVM can no longer parse.
  */
 final class RootImporter implements Builder {
-  private Vector<Builder> $builders = Vector {};
+  private vec<Builder> $builders = vec[];
   private HHImporter $hh_importer;
 
   public function __construct(

--- a/tests/BaseTest.hack
+++ b/tests/BaseTest.hack
@@ -10,8 +10,8 @@
 namespace Facebook\AutoloadMap;
 
 abstract class BaseTest extends \Facebook\HackTest\HackTest {
-  public function getParsers(): array<(Parser, classname<Builder>)> {
-    return varray[
+  public function getParsers(): vec<(Parser, classname<Builder>)> {
+    return vec[
       tuple(Parser::EXT_FACTPARSE, FactParseScanner::class),
     ];
   }

--- a/tests/ConfigurationLoaderTest.hack
+++ b/tests/ConfigurationLoaderTest.hack
@@ -65,7 +65,7 @@ final class ConfigurationLoaderTest extends \Facebook\HackTest\HackTest {
         expect($config)->toNotContainKey($key);
       } else if (\is_array($value)) {
         $value = vec($value);
-        expect(vec($config[$key] as Traversable<_>))->toBePHPEqual($value);
+        expect($config[$key])->toBePHPEqual($value);
       } else {
         expect($config[$key])->toBeSame($value);
       }

--- a/tests/ConfigurationLoaderTest.hack
+++ b/tests/ConfigurationLoaderTest.hack
@@ -21,11 +21,11 @@ final class ConfigurationLoaderTest extends \Facebook\HackTest\HackTest {
         'autoloadFilesBehavior' => self::IGNORED_VALUE,
         'relativeAutoloadRoot' => false,
         'includeVendor' => false,
-        'extraFiles' => varray[],
-        'roots' => varray['foo/', 'bar/'],
+        'extraFiles' => vec[],
+        'roots' => vec['foo/', 'bar/'],
         'parser' => 'ext-factparse',
       ]),
-      'just roots' => tuple(darray['roots' => varray['foo/', 'bar/']]),
+      'just roots' => tuple(darray['roots' => vec['foo/', 'bar/']]),
     ];
   }
 
@@ -57,15 +57,12 @@ final class ConfigurationLoaderTest extends \Facebook\HackTest\HackTest {
     array<string, mixed> $data,
     Config $config,
   ): void {
-    expect(varray($config['roots']))->toBePHPEqual($data['roots']);
+    expect($config['roots'])->toEqual($data['roots']);
 
     $config = Shapes::toArray($config);
     foreach ($data as $key => $value) {
       if ($value === self::IGNORED_VALUE) {
         expect($config)->toNotContainKey($key);
-      } else if (\is_array($value)) {
-        $value = vec($value);
-        expect($config[$key])->toBePHPEqual($value);
       } else {
         expect($config[$key])->toBeSame($value);
       }

--- a/tests/ConfigurationLoaderTest.hack
+++ b/tests/ConfigurationLoaderTest.hack
@@ -15,17 +15,17 @@ use function Facebook\FBExpect\expect;
 final class ConfigurationLoaderTest extends \Facebook\HackTest\HackTest {
   const IGNORED_VALUE = '__ignore__';
 
-  public function goodTestCases(): array<string, array<array<string, mixed>>> {
-    return darray[
-      'fully specified' => varray[darray[
+  public function goodTestCases(): dict<string, (darray<string, mixed>)> {
+    return dict[
+      'fully specified' => tuple(darray[
         'autoloadFilesBehavior' => self::IGNORED_VALUE,
         'relativeAutoloadRoot' => false,
         'includeVendor' => false,
         'extraFiles' => varray[],
         'roots' => varray['foo/', 'bar/'],
         'parser' => 'ext-factparse',
-      ]],
-      'just roots' => varray[darray['roots' => varray['foo/', 'bar/']]],
+      ]),
+      'just roots' => tuple(darray['roots' => varray['foo/', 'bar/']]),
     ];
   }
 

--- a/tests/ConfigurationLoaderTest.hack
+++ b/tests/ConfigurationLoaderTest.hack
@@ -15,9 +15,9 @@ use function Facebook\FBExpect\expect;
 final class ConfigurationLoaderTest extends \Facebook\HackTest\HackTest {
   const IGNORED_VALUE = '__ignore__';
 
-  public function goodTestCases(): dict<string, (darray<string, mixed>)> {
+  public function goodTestCases(): dict<string, (dict<string, mixed>)> {
     return dict[
-      'fully specified' => tuple(darray[
+      'fully specified' => tuple(dict[
         'autoloadFilesBehavior' => self::IGNORED_VALUE,
         'relativeAutoloadRoot' => false,
         'includeVendor' => false,
@@ -25,24 +25,24 @@ final class ConfigurationLoaderTest extends \Facebook\HackTest\HackTest {
         'roots' => vec['foo/', 'bar/'],
         'parser' => 'ext-factparse',
       ]),
-      'just roots' => tuple(darray['roots' => vec['foo/', 'bar/']]),
+      'just roots' => tuple(dict['roots' => vec['foo/', 'bar/']]),
     ];
   }
 
   <<DataProvider('goodTestCases')>>
-  public function testDataLoader(array<string, mixed> $data): void {
+  public function testDataLoader(dict<string, mixed> $data): void {
     $config = ConfigurationLoader::fromData($data, '/dev/null');
     $this->assertGoodConfig($data, $config);
   }
 
   <<DataProvider('goodTestCases')>>
-  public function testJSONLoader(array<string, mixed> $data): void {
+  public function testJSONLoader(dict<string, mixed> $data): void {
     $config = ConfigurationLoader::fromJSON(\json_encode($data), '/dev/null');
     $this->assertGoodConfig($data, $config);
   }
 
   <<DataProvider('goodTestCases')>>
-  public function testFileLoader(array<string, mixed> $data): void {
+  public function testFileLoader(dict<string, mixed> $data): void {
     $fname = \tempnam(\sys_get_temp_dir(), 'testjson');
     try {
       \file_put_contents($fname, \json_encode($data));
@@ -54,7 +54,7 @@ final class ConfigurationLoaderTest extends \Facebook\HackTest\HackTest {
   }
 
   private function assertGoodConfig(
-    array<string, mixed> $data,
+    dict<string, mixed> $data,
     Config $config,
   ): void {
     expect($config['roots'])->toEqual($data['roots']);

--- a/tests/ConfigurationLoaderTest.hack
+++ b/tests/ConfigurationLoaderTest.hack
@@ -64,7 +64,7 @@ final class ConfigurationLoaderTest extends \Facebook\HackTest\HackTest {
       if ($value === self::IGNORED_VALUE) {
         expect($config)->toNotContainKey($key);
       } else {
-        expect($config[$key])->toBeSame($value);
+        expect($config[$key])->toEqual($value);
       }
     }
   }

--- a/tests/ConfigurationLoaderTest.hack
+++ b/tests/ConfigurationLoaderTest.hack
@@ -57,15 +57,15 @@ final class ConfigurationLoaderTest extends \Facebook\HackTest\HackTest {
     array<string, mixed> $data,
     Config $config,
   ): void {
-    expect($config['roots']->toArray())->toBePHPEqual($data['roots']);
+    expect(varray($config['roots']))->toBePHPEqual($data['roots']);
 
     $config = Shapes::toArray($config);
     foreach ($data as $key => $value) {
       if ($value === self::IGNORED_VALUE) {
         expect($config)->toNotContainKey($key);
       } else if (\is_array($value)) {
-        $value = new ImmVector($value);
-        expect($config[$key])->toBePHPEqual($value);
+        $value = vec($value);
+        expect(vec($config[$key] as Traversable<_>))->toBePHPEqual($value);
       } else {
         expect($config[$key])->toBeSame($value);
       }

--- a/tests/RootImporterTest.hack
+++ b/tests/RootImporterTest.hack
@@ -9,6 +9,7 @@
 
 namespace Facebook\AutoloadMap;
 
+use namespace HH\Lib\Vec;
 use type Facebook\HackTest\DataProvider;
 use function Facebook\FBExpect\expect;
 
@@ -54,14 +55,17 @@ final class RootImporterTest extends BaseTest {
       ->writeToFile($tempfile);
 
     $cmd = (
-      Vector {
-        \PHP_BINARY,
-        '-v',
-        'Eval.Jit=0',
-        __DIR__.'/fixtures/hh-only/'.$test_file,
-        $tempfile,
-      }
-    )->map($x ==> \escapeshellarg($x));
+      Vec\map(
+        vec[
+          \PHP_BINARY,
+          '-v',
+          'Eval.Jit=0',
+          __DIR__.'/fixtures/hh-only/'.$test_file,
+          $tempfile,
+        ],
+        $x ==> \escapeshellarg($x),
+      )
+    );
     $cmd = \implode(' ', $cmd);
 
     $output = varray[];

--- a/tests/RootImporterTest.hack
+++ b/tests/RootImporterTest.hack
@@ -27,8 +27,8 @@ final class RootImporterTest extends BaseTest {
     expect($importer->getFiles())->toBeEmpty();
   }
 
-  public function provideTestModes(): array<(IncludedRoots, string, bool)> {
-    return varray[
+  public function provideTestModes(): vec<(IncludedRoots, string, bool)> {
+    return vec[
       tuple(IncludedRoots::PROD_ONLY, 'test-prod.php', true),
       tuple(IncludedRoots::PROD_ONLY, 'test-prod.php', false),
       tuple(IncludedRoots::DEV_AND_PROD, 'test-dev.php', true),

--- a/tests/ScannerTest.hack
+++ b/tests/ScannerTest.hack
@@ -83,8 +83,8 @@ final class ScannerTest extends BaseTest {
   }
 
   private function assertMapMatches(
-    KeyedContainer<string, string> $expected,
-    KeyedContainer<string, string> $actual,
+    dict<string, string> $expected,
+    dict<string, string> $actual,
   ): void {
     foreach ($expected as $name => $file) {
       $a = self::HH_ONLY_SRC.'/'.$file;

--- a/tests/ScannerTest.hack
+++ b/tests/ScannerTest.hack
@@ -22,7 +22,7 @@ final class ScannerTest extends BaseTest {
     $map = Scanner::fromTree(self::HH_ONLY_SRC, $parser)->getAutoloadMap();
 
     $this->assertMapMatches(
-      darray[
+      dict[
         'ExampleClassInHH' => 'class_in_hh.hh',
         'ExampleClass' => 'class.php',
         'ExampleEnum' => 'enum.php',
@@ -32,12 +32,12 @@ final class ScannerTest extends BaseTest {
     );
 
     $this->assertMapMatches(
-      darray['example_function' => 'function.php'],
+      dict['example_function' => 'function.php'],
       $map['function'],
     );
 
     $this->assertMapMatches(
-      darray[
+      dict[
         'ExampleType' => 'type.php',
         'ExampleNewtype' => 'newtype.php',
       ],
@@ -45,7 +45,7 @@ final class ScannerTest extends BaseTest {
     );
 
     $this->assertMapMatches(
-      darray[
+      dict[
         'FREDEMMOTT_AUTOLOAD_MAP_TEST_FIXTURES_EXAMPLE_CONSTANT' =>
           'constant.php',
       ],
@@ -74,7 +74,7 @@ final class ScannerTest extends BaseTest {
     expect($map['function'])->toBeEmpty();
     expect($map['type'])->toBeEmpty();
     $this->assertMapMatches(
-      darray[
+      dict[
         'FREDEMMOTT_AUTOLOAD_MAP_TEST_FIXTURES_EXAMPLE_CONSTANT' =>
           'constant.php',
       ],
@@ -83,8 +83,8 @@ final class ScannerTest extends BaseTest {
   }
 
   private function assertMapMatches(
-    array<string, string> $expected,
-    array<string, string> $actual,
+    KeyedContainer<string, string> $expected,
+    KeyedContainer<string, string> $actual,
   ): void {
     foreach ($expected as $name => $file) {
       $a = self::HH_ONLY_SRC.'/'.$file;


### PR DESCRIPTION
This is not intended to change the behavior of the program.
This just makes the code more 2020-ish.

Sadly, the formatting wasn't quite stable.

Please be careful with the review.
This library is **_extremely_** critical.

My plan of attack was:

Upgrade varray and darary to vec and dict first, since they don't have very different behavior.
The remove Imm collections, since they effectively have value semantics (no code can rely on changing the elements.)
Const collections _should_ be just as safe as Imm collections, but type refinement might downcast something to a mutable collection at runtime. Therefore, I did this in a different step.
Lastly, the part where I needed to be 100% more careful, removing the mutable collections. As far as my reading can prove to me, no code relied on them being a non-value object. The Vectors weren't passes around in mutable positions. They're also private.