### PR TITLE
Match "typedef" as a kind in the fallback handler

### DIFF
--- a/src/HHClientFallbackHandler.hack
+++ b/src/HHClientFallbackHandler.hack
@@ -17,7 +17,7 @@ use namespace HH\Lib\{C, Str, Vec};
  * This caches the results in APC (falling back to a file) to provide fast
  * workflows.
  *
- * Does nothing if CI, TRAVIS, or CONTINOUS_INTEGRATION is true.
+ * Does nothing if CI, TRAVIS, or CONTINUOUS_INTEGRATION is true.
  */
 class HHClientFallbackHandler extends FailureHandler {
   private AutoloadMap $map;

--- a/src/HHClientFallbackHandler.hack
+++ b/src/HHClientFallbackHandler.hack
@@ -204,6 +204,7 @@ class HHClientFallbackHandler extends FailureHandler {
         $this->map['class'][\strtolower($name)] = $path;
         break;
       case 'type':
+      case 'typedef':
         $this->map['type'][\strtolower($name)] = $path;
         break;
       case 'function':


### PR DESCRIPTION
This switch cause a RuntimeException for not being exhaustive.