### PR TITLE
Set branch and version alias for CI on pull requests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -54,6 +54,8 @@ jobs:
         run: |
           hhvm --version
           hh_client --version
+      - name: Create branch for version alias
+        run: git checkout -b CI_current_pull_request
       - name: Install project dependencies
         run: php ${{runner.temp}}/composer.phar install
       - name: Run autoloader

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
       "Facebook\\AutoloadMap\\ComposerPlugin"
     ],
     "branch-alias": {
-      "dev-master": "2.x-dev"
+      "dev-master": "2.x-dev",
+      "dev-CI_current_pull_request": "2.x-dev"
     }
   }
 }


### PR DESCRIPTION
refs #62

This is based on the trick in the HSL's `.travis.sh`, but uses a new
explicit branch name instead of nuking 'master'.