### PR TITLE
Remove // partial

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ ubuntu , macos ]
         hhvm:
-          - '4.25'
+          - '4.67'
           - latest
           - nightly
     runs-on: ${{matrix.os}}-latest

--- a/.hhconfig
+++ b/.hhconfig
@@ -12,3 +12,4 @@ disallow_array_literal = true
 disallow_silence = true
 allowed_decl_fixme_codes=2053,4045
 allowed_fixme_codes_strict=2011,2049,2050,2053,4027,4045,4106,4107,4108,4110,4128,4135,4188,4240,4323
+disable_modes=true

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "composer-plugin-api": "^1.0|^2.0",
-    "hhvm": "^4.25",
+    "hhvm": "^4.67",
     "hhvm/hsl": "^4.0"
   },
   "require-dev": {

--- a/src/Writer.hack
+++ b/src/Writer.hack
@@ -80,14 +80,6 @@ final class Writer {
 
   public function writeToDirectory(string $directory): this {
     $this->writeToFile($directory.'/autoload.hack');
-    foreach (keyset['hh_autoload.php', 'hh_autoload.hh'] as $legacy_file) {
-      \file_put_contents(
-        $directory.'/'.$legacy_file,
-        "<?hh // partial\n".
-        "require_once(__DIR__.'/autoload.hack');\n".
-        "Facebook\AutoloadMap\initialize();\n",
-      );
-    }
 
     return $this;
   }

--- a/testdata/MixedCaseClass.php
+++ b/testdata/MixedCaseClass.php
@@ -1,4 +1,4 @@
-<?hh // partial
+<?hh
 /*
  *  Copyright (c) 2015-present, Facebook, Inc.
  *  All rights reserved.

--- a/testdata/MixedCaseConstant.php
+++ b/testdata/MixedCaseConstant.php
@@ -1,4 +1,4 @@
-<?hh // partial
+<?hh
 /*
  *  Copyright (c) 2015-present, Facebook, Inc.
  *  All rights reserved.

--- a/testdata/MixedCaseFunction.php
+++ b/testdata/MixedCaseFunction.php
@@ -1,4 +1,4 @@
-<?hh // partial
+<?hh
 /*
  *  Copyright (c) 2015-present, Facebook, Inc.
  *  All rights reserved.

--- a/testdata/MixedCaseType.php
+++ b/testdata/MixedCaseType.php
@@ -1,4 +1,4 @@
-<?hh // partial
+<?hh
 /*
  *  Copyright (c) 2015-present, Facebook, Inc.
  *  All rights reserved.

--- a/testdata/fixtures/hh-only/test-dev.php
+++ b/testdata/fixtures/hh-only/test-dev.php
@@ -1,4 +1,4 @@
-<?hh // partial
+<?hh
 /*
  *  Copyright (c) 2015-present, Facebook, Inc.
  *  All rights reserved.


### PR DESCRIPTION
The legacy files have not worked since 4.67.
Top level code is not a thing anymore.
These files generate errors when disable_modes is true.
Bumped the minimum hhvm version
to not break for users that are relying on these files.
If composer installs this version for you, the file
would have thrown a top-level code \Error anyway.