### PR TITLE
Export sorted map

### DIFF
--- a/src/Writer.hack
+++ b/src/Writer.hack
@@ -164,9 +164,20 @@ final class Writer {
       true,
     );
 
-    $map = \var_export($map, true)
-      |> \str_replace('array (', 'dict[', $$)
-      |> \str_replace(')', ']', $$);
+    \ksort(inout $map);
+    $map_export = "darray[\n";
+    foreach ($map as $type => $mapping) {
+      $map_export .= "  '{$type}' => \n  darray[\n";
+      $mapping = $mapping as KeyedContainer<_, _>;
+      \ksort(inout $mapping);
+      foreach ($mapping as $k => $v) {
+        $v = (string)$v;
+        $map_export .= "    '{$k}' => '{$v}',\n";
+      }
+      $map_export = $map_export."  ],\n";
+    }
+    $map_export = $map_export."];\n";
+    $map = $map_export;
 
     if ($this->relativeAutoloadRoot) {
       try {

--- a/src/Writer.hack
+++ b/src/Writer.hack
@@ -165,9 +165,9 @@ final class Writer {
     );
 
     \ksort(inout $map);
-    $map_export = "darray[\n";
+    $map_export = "dict[\n";
     foreach ($map as $type => $mapping) {
-      $map_export .= "  '{$type}' => \n  darray[\n";
+      $map_export .= "  '{$type}' => \n  dict[\n";
       $mapping = $mapping as KeyedContainer<_, _>;
       \ksort(inout $mapping);
       foreach ($mapping as $k => $v) {


### PR DESCRIPTION
## Description
Manually generate the exported autoload map in sorted order.

## Details
At Slack we commit the vendor autoload map to source control, which makes diffs hard to comprehend given that the map is unordered.

This change replaces the var_export with manually generated code after sorting the arrays so that the generated autoload map should be stable.

## CLA
@ssandler requested that I be added to the Slack corporate CLA at some point.