### PR TITLE
Play nice with native autoloaders

### DIFF
--- a/bin/hh-autoload.hack
+++ b/bin/hh-autoload.hack
@@ -129,14 +129,13 @@ final class GenerateScript {
           "hh_autoload.json\n",
         );
         exit(1);
-      } else {
-        \fwrite(
-          \STDERR,
-          "hh_autoload.json could not be found, but a native autoloader was detected.\n".
-          "If you intend to use native autoloading, you may ignore this message.\n",
-        );
-        exit(0);
       }
+      \fwrite(
+        \STDERR,
+        "hh_autoload.json could not be found, but a native autoloader was detected.\n".
+        "If you intend to use native autoloading, you may ignore this message.\n",
+      );
+      exit(0);
     }
   }
 

--- a/src/ConfigurationLoader.hack
+++ b/src/ConfigurationLoader.hack
@@ -9,7 +9,7 @@
 
 namespace Facebook\AutoloadMap;
 
-use Facebook\AutoloadMap\__Private\TypeAssert;
+use Facebook\AutoloadMap\_Private\TypeAssert;
 
 /** Load configuration from JSON */
 abstract final class ConfigurationLoader {

--- a/src/DO_NOT_REQUIRE_THIS_FILE.hack
+++ b/src/DO_NOT_REQUIRE_THIS_FILE.hack
@@ -1,0 +1,12 @@
+/*
+ *  Copyright (c) 2015-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\AutoloadMap\_Private;
+
+final class DummyClassToDetectNativeAutoloader {}

--- a/src/TypeAssert.hack
+++ b/src/TypeAssert.hack
@@ -8,7 +8,7 @@
  */
 
 // Special-casing minimal reimplementation to avoid the dependency
-namespace Facebook\AutoloadMap\__Private\TypeAssert;
+namespace Facebook\AutoloadMap\_Private\TypeAssert;
 
 function is_string(mixed $value, string $field): string {
   invariant($value is string, '%s should be a string', $field);

--- a/src/Writer.hack
+++ b/src/Writer.hack
@@ -230,6 +230,11 @@ function initialize(): void {
   if (_Private\GlobalState::\$initialized) {
     return;
   }
+  if (\class_exists(_Private\DummyClassToDetectNativeAutoloader::class)) {
+    // Some form of native autoloading is happening.
+    // Let's not trample over the native autoloader(s).
+    return;
+  }
   _Private\GlobalState::\$initialized = true;
   _Private\bootstrap();
   \$map = Generated\\map();

--- a/src/builders/FactParseScanner.hack
+++ b/src/builders/FactParseScanner.hack
@@ -9,7 +9,7 @@
 
 namespace Facebook\AutoloadMap;
 
-use Facebook\AutoloadMap\__Private\TypeAssert;
+use Facebook\AutoloadMap\_Private\TypeAssert;
 
 /** Create an autoload map from a directory using `ext_factparse`. */
 final class FactParseScanner implements Builder {


### PR DESCRIPTION
If a native autoloader has control:
 - Do not exit with status code 1 if hh_autoload.json is missing.
 - Bail out early from AutoloadMap\initialize().

If you depend on f.e. hhast, you get hhvm-autoload. If you intend to use native autoloading, hhvm-autoload should not cause your composer install to fail.

When using hhvm-autoload for development and repo auth autoloading in prod, we can safely make `Facebook\AutoloadMap\initialize()` a noop in prod.