### PR TITLE
Update minimal HHVM version to 4.144

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ ubuntu , macos ]
         hhvm:
-          - '4.135'
+          - '4.144'
           - latest
           - nightly
     runs-on: ${{matrix.os}}-latest

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "composer-plugin-api": "^1.0|^2.0",
-    "hhvm": "^4.135",
+    "hhvm": "^4.144",
     "hhvm/hsl": "^4.0"
   },
   "require-dev": {


### PR DESCRIPTION
4.135 is an unsupported version, which is known incompatible with latest Boost binary from Homebrew.