### PR TITLE
Support hhvm-nightly, expected to support 4.161.

### DIFF
--- a/bin/hh-autoload.hack
+++ b/bin/hh-autoload.hack
@@ -69,16 +69,16 @@ final class GenerateScript {
         continue;
       }
       $file_facts = $file_facts as dynamic;
-      foreach ($file_facts['types'] as $type) {
+      foreach ($file_facts['types'] ?? vec[] as $type) {
         $map['class'][\strtolower($type['name'] as string)] = $path;
       }
-      foreach ($file_facts['constants'] as $const) {
+      foreach ($file_facts['constants'] ?? vec[] as $const) {
         $map['constant'][$const as string] = $path;
       }
-      foreach ($file_facts['functions'] as $fun) {
+      foreach ($file_facts['functions'] ?? vec[] as $fun) {
         $map['function'][\strtolower($fun as string)] = $path;
       }
-      foreach ($file_facts['typeAliases'] as $type) {
+      foreach ($file_facts['typeAliases'] ?? vec[] as $type) {
         $map['type'][\strtolower($type as string)] = $path;
       }
     }
@@ -152,8 +152,8 @@ final class GenerateScript {
       ? $config['devFailureHandler']
       : $config['failureHandler'];
 
-    $emit_facts_forwarder_file = $config['useFactsIfAvailable'] &&
-      !$options['no-facts'];
+    $emit_facts_forwarder_file =
+      $config['useFactsIfAvailable'] && !$options['no-facts'];
 
     (new Writer())
       ->setBuilder($importer)

--- a/src/TypeAssert.hack
+++ b/src/TypeAssert.hack
@@ -82,18 +82,21 @@ function is_nullable_enum<Tval as arraykey, T as \HH\BuiltinEnum<Tval>>(
   return $value;
 }
 
-function is_array_of_shapes_with_name_field(
+function is_array_of_shapes_with_name_field_and_kind(
   mixed $value,
   string $field,
-): varray<shape('name' => string)> {
-  $msg = $field.'should be an vec<shape(\'name\' => string)>';
+): varray<shape('name' => string, 'kindOf' => string)> {
+  $msg =
+    $field.'should be a vec<shape(\'name\' => string, \'kindOf\' => string)>';
   invariant($value is Traversable<_>, '%s', $msg);
   $out = varray[];
   foreach ($value as $it) {
     invariant($it is KeyedContainer<_, _>, '%s', $msg);
     $name = $it['name'] ?? null;
     invariant($name is string, '%s', $msg);
-    $out[] = shape('name' => $name);
+    $kind_of = $it['kindOf'] ?? null;
+    invariant($kind_of is string, '%s', $msg);
+    $out[] = shape('name' => $name, 'kindOf' => $kind_of);
   }
   return $out;
 }

--- a/src/TypeAssert.hack
+++ b/src/TypeAssert.hack
@@ -86,7 +86,7 @@ function is_array_of_shapes_with_name_field(
   mixed $value,
   string $field,
 ): varray<shape('name' => string)> {
-  $msg = $field.'should be an array<shape(\'name\' => string)>';
+  $msg = $field.'should be an vec<shape(\'name\' => string)>';
   invariant($value is Traversable<_>, '%s', $msg);
   $out = varray[];
   foreach ($value as $it) {

--- a/src/builders/FactParseScanner.hack
+++ b/src/builders/FactParseScanner.hack
@@ -40,19 +40,19 @@ final class FactParseScanner implements Builder {
       try {
         $out[$file] = shape(
           'types' => TypeAssert\is_array_of_shapes_with_name_field(
-            $facts['types'] ?? null,
+            $facts['types'] ?? vec[],
             'FactParse types',
           ),
           'constants' => TypeAssert\is_array_of_strings(
-            $facts['constants'] ?? null,
+            $facts['constants'] ?? vec[],
             'FactParse constants',
           ),
           'functions' => TypeAssert\is_array_of_strings(
-            $facts['functions'] ?? null,
+            $facts['functions'] ?? vec[],
             'FactParse functions',
           ),
           'typeAliases' => TypeAssert\is_array_of_strings(
-            $facts['typeAliases'] ?? null,
+            $facts['typeAliases'] ?? vec[],
             'FactParse typeAliases',
           ),
         );


### PR DESCRIPTION
A recent change in HH\facts_parse() made it no longer return empty vecs
for entities kinds that are not declared in the file.
So files without constants do not return `"constants" => vec[]` anymore.
Supply a default value of `vec[]` to match the old behavior and fix CI.